### PR TITLE
 Updates Blog Table of Contents to have alternating colors in titles

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -24,7 +24,7 @@
 }
 
 [title="January"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="February"] {
@@ -32,7 +32,7 @@
 }
 
 [title="February"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="March"] {
@@ -40,7 +40,7 @@
 }
 
 [title="March"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="April"] {
@@ -48,7 +48,7 @@
 }
 
 [title="April"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="May"] {
@@ -56,7 +56,7 @@
 }
 
 [title="May"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="June"] {
@@ -64,7 +64,7 @@
 }
 
 [title="June"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="July"] {
@@ -72,7 +72,7 @@
 }
 
 [title="July"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="August"] {
@@ -80,7 +80,7 @@
 }
 
 [title="August"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="September"] {
@@ -88,7 +88,7 @@
 }
 
 [title="September"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="October"] {
@@ -96,7 +96,7 @@
 }
 
 [title="October"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="November"] {
@@ -104,7 +104,7 @@
 }
 
 [title="November"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 [title="December"] {
@@ -112,7 +112,7 @@
 }
 
 [title="December"] + nav > ul > li:nth-child(even) {
-  color: #8a8888;
+  color: #969696;
 }
 
 .md-typeset blockquote {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -74,7 +74,3 @@
 label[for="toc"] + ul > li > a + nav > ul > li > a {
   color: #bdbdbd;
 }
-
-label[for="toc"] + ul > li > a + nav > ul > li > a:hover {
-  color: #536dfe;
-}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -19,99 +19,99 @@
   border-left: 0.4rem solid #00d3e3;
 }
 
-[title~="January"] {
+[title="January"] {
   font-weight: bold;
 }
 
-[title~="January"] + nav > ul > li:nth-child(even) {
+[title="January"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="February"] {
+[title="February"] {
   font-weight: bold;
 }
 
-[title~="February"] + nav > ul > li:nth-child(even) {
+[title="February"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="March"] {
+[title="March"] {
   font-weight: bold;
 }
 
-[title~="March"] + nav > ul > li:nth-child(even) {
+[title="March"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="April"] {
+[title="April"] {
   font-weight: bold;
 }
 
-[title~="April"] + nav > ul > li:nth-child(even) {
+[title="April"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="May"] {
+[title="May"] {
   font-weight: bold;
 }
 
-[title~="May"] + nav > ul > li:nth-child(even) {
+[title="May"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="June"] {
+[title="June"] {
   font-weight: bold;
 }
 
-[title~="June"] + nav > ul > li:nth-child(even) {
+[title="June"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="July"] {
+[title="July"] {
   font-weight: bold;
 }
 
-[title~="July"] + nav > ul > li:nth-child(even) {
+[title="July"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="August"] {
+[title="August"] {
   font-weight: bold;
 }
 
-[title~="August"] + nav > ul > li:nth-child(even) {
+[title="August"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="September"] {
+[title="September"] {
   font-weight: bold;
 }
 
-[title~="September"] + nav > ul > li:nth-child(even) {
+[title="September"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="October"] {
+[title="October"] {
   font-weight: bold;
 }
 
-[title~="October"] + nav > ul > li:nth-child(even) {
+[title="October"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="November"] {
+[title="November"] {
   font-weight: bold;
 }
 
-[title~="November"] + nav > ul > li:nth-child(even) {
+[title="November"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 
-[title~="December"] {
+[title="December"] {
   font-weight: bold;
 }
 
-[title~="December"] + nav > ul > li:nth-child(even) {
+[title="December"] + nav > ul > li:nth-child(even) {
   color: #8a8888;
 }
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,71 +1,80 @@
-[data-md-color-primary=blue-grey] .md-header {
-    background-color: #373737;
+[data-md-color-primary="blue-grey"] .md-header {
+  background-color: #373737;
 }
 
 .md-search__input {
-    border-radius: .2rem .2rem 0 0;
-    background-color: #606060;
-    color: rgba(0,0,0,.87);
-    text-overflow: none;
-    border-radius: 4px;
+  border-radius: 0.2rem 0.2rem 0 0;
+  background-color: #606060;
+  color: rgba(0, 0, 0, 0.87);
+  text-overflow: none;
+  border-radius: 4px;
 }
 
-[data-md-color-primary=blue-grey] .md-nav__link--active, [data-md-color-primary=blue-grey] .md-nav__link:active {
-    color: #2FB7DE;
+[data-md-color-primary="blue-grey"] .md-nav__link--active,
+[data-md-color-primary="blue-grey"] .md-nav__link:active {
+  color: #2fb7de;
 }
 
-[data-md-color-primary=blue-grey] .md-nav--secondary {
-    border-left: .4rem solid #00d3e3;
+[data-md-color-primary="blue-grey"] .md-nav--secondary {
+  border-left: 0.4rem solid #00d3e3;
 }
 
 [title~="January"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="February"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="March"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="April"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="May"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="June"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="July"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="August"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="September"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="October"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="November"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 [title~="December"] {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .md-typeset blockquote {
-  border-left: .4rem solid #00CBE6;
+  border-left: 0.4rem solid #00cbe6;
+}
+
+label[for="toc"] + ul > li > a + nav > ul > li > a {
+  color: #bdbdbd;
+}
+
+label[for="toc"] + ul > li > a + nav > ul > li > a:hover {
+  color: #536dfe;
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -23,54 +23,98 @@
   font-weight: bold;
 }
 
+[title~="January"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
+}
+
 [title~="February"] {
   font-weight: bold;
+}
+
+[title~="February"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
 }
 
 [title~="March"] {
   font-weight: bold;
 }
 
+[title~="March"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
+}
+
 [title~="April"] {
   font-weight: bold;
+}
+
+[title~="April"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
 }
 
 [title~="May"] {
   font-weight: bold;
 }
 
+[title~="May"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
+}
+
 [title~="June"] {
   font-weight: bold;
+}
+
+[title~="June"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
 }
 
 [title~="July"] {
   font-weight: bold;
 }
 
+[title~="July"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
+}
+
 [title~="August"] {
   font-weight: bold;
+}
+
+[title~="August"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
 }
 
 [title~="September"] {
   font-weight: bold;
 }
 
+[title~="September"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
+}
+
 [title~="October"] {
   font-weight: bold;
+}
+
+[title~="October"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
 }
 
 [title~="November"] {
   font-weight: bold;
 }
 
+[title~="November"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
+}
+
 [title~="December"] {
   font-weight: bold;
 }
 
-.md-typeset blockquote {
-  border-left: 0.4rem solid #00cbe6;
+[title~="December"] + nav > ul > li:nth-child(even) {
+  color: #8a8888;
 }
 
-label[for="toc"] + ul > li > a + nav > ul > li > a {
-  color: #bdbdbd;
+.md-typeset blockquote {
+  border-left: 0.4rem solid #00cbe6;
 }


### PR DESCRIPTION
This PR makes parent titles black and sub-titles light grey which helps readability a lot. The light grey was selected from Material Design's color palette. It's shown below:
<img width="1552" alt="screen shot 2018-01-11 at 8 28 02 pm" src="https://user-images.githubusercontent.com/12488826/34855639-d5398a72-f70e-11e7-94c8-aee57e493972.png">

(Also other CSS lines were edited because [Prettier](https://prettier.io/) reformatted them that way)

Fixes #6