### PR TITLE
Remove link to non-working mainnet proposals app

### DIFF
--- a/docs/documentation/governance.md
+++ b/docs/documentation/governance.md
@@ -1,7 +1,7 @@
 # Aragon Governance
 
 - Check out [**all open Aragon Governance Proposals**](https://github.com/aragon/governance/issues)
-- Vote on [**open surveys for ANT holders**](https://survey.aragon.org)
+- We are currently rebuilding the proposal module on Aragon, which will be deployed to the Ethereum mainnet.
 
 ## Finalized AGPs
 


### PR DESCRIPTION
The mainnet proposals app linked through survey.aragon.org is down. While it will be replaced, the wiki should not lead curious people to the dead location.