### PR TITLE
Update bug bounty

### DIFF
--- a/docs/dev/bug_bounty.md
+++ b/docs/dev/bug_bounty.md
@@ -18,7 +18,7 @@ Vulnerability reports will be scored using the  [CVSS v3](https://www.first.org/
 !!! warning "**Low** (CVSS 1.0 - 3.9)"
     $500-$1,000
 
-Rewards will be awarded at the sole discretion of Aragon. Quality of the report and reproduction instructions can impact the reward. Rewards will be paid out in ETH.
+Rewards will be awarded at the sole discretion of the Aragon Association. Quality of the report and reproduction instructions can impact the reward. Rewards will be paid out in ETH.
 
 For this initial bug bounty program there is a **maximum bounty pool of $250,000**.
 
@@ -36,30 +36,31 @@ The bug bounty program will run for a minimum of three months, starting October 
 
 In scope for the bug bounty are all the smart contract components of the Aragon client. They can be found on three main repositories:
 
-!!! abstract "**aragonOS 4** ([https://github.com/aragon/aragonOS](https://github.com/aragon/aragonOS))"
+!!! abstract "**aragonOS 4** ([https://github.com/aragon/aragonOS@4.0.0](https://github.com/aragon/aragonOS/tree/v4.0.0) and [future patch versions](https://github.com/aragon/aragonOS/releases))"
     Smart contract framework and core of the system.
 
     - Solidity code under the `contracts` directory:
-        - Excluding `contracts/lib/`, except for `contracts/lib/math` contracts
+        - Excluding `contracts/lib/ens` contracts
         - Excluding `contracts/test/`
 
-!!! abstract "**aragon-apps** ([https://github.com/aragon/aragon-apps](https://github.com/aragon/aragon-apps))"
-    Contracts for aragonOS apps that Aragon develops that are used in DAOs.
+!!! abstract "**aragon-apps** ([https://github.com/aragon/aragon-apps](https://github.com/aragon/aragon-apps/tree/master) on the [master branch](https://github.com/aragon/aragon-apps/tree/master))"
+    Contracts for Aragon apps developed by the Aragon Association and are used by default in most Aragon 0.6 organizations.
 
     - Solidity code under `apps/**/contracts` (`voting`, `vault`, `finance`, `token-manager`, `survey`)
         - Excluding `contracts/test`
     - Solidity code under `shared/minime/contracts`
 
-!!! abstract "**dao-templates** ([https://github.com/aragon/dao-kits](https://github.com/aragon/dao-kits))"
-    On-chain deployment scripts for Aragon DAOs.
+!!! abstract "**dao-templates** ([https://github.com/aragon/dao-kits](https://github.com/aragon/dao-kits/tree/master) on the [master branch](https://github.com/aragon/dao-kits/tree/master))"
+    On-chain deployment templates for Aragon DAOs.
 
     - Solidity code for the following templates: `bare`, `beta-base`, `democracy`, `multisig`, `survey`
         - Excluding `contracts/test`
 
+You can find their deployed addresses on live networks in our [deployment documentation](https://github.com/aragon/deployments).
+
 ## Areas of interest
 
 !!! tip "These are some examples of vulnerabilities that would be interesting"
-
     - Bypassing ACL rules to get unauthorized access to an app.
     - A user of an app performing an action that could freeze or lock the contract.
     - Being able to escalate permissions using the Voting app or Token Manager without a proper vote being successful.
@@ -68,19 +69,21 @@ In scope for the bug bounty are all the smart contract components of the Aragon 
 
 !!! question "What we consider out of scope for this bug bounty"
     - Side-effects of properly authenticated smart contract upgrades or contract upgrades that change the storage layout of a contract.
-    - Revocation of permissions or completely changing how a DAO operates due to an important permission being granted using the proper process.
+    - Revocation of permissions or completely changing how a DAO operates due to an important permission being granted through the proper processes.
     - Any frontend applications or client-side code interacting with the contracts, as well as testing code.
     - Mismatch of the functionality of the contracts and outdated spec documents.
 
 ## Resources
 
 !!! snippet "Documentation and resources for hackers"
-    - Reference and documentation for aragonOS 3 can be found here ([https://hack.aragon.org/docs/aragonos-ref.html](https://hack.aragon.org/docs/aragonos-ref.html)) and a list of the changes that have been made for aragonOS 4 ([https://github.com/aragon/aragonOS/wiki/aragonOS-4:-Updates-to-aragonOS-and-aragon-apps](https://github.com/aragon/aragonOS/wiki/aragonOS-4:-Updates-to-aragonOS-and-aragon-apps)).
-    - Documentation on how aragonOS apps should be developed: [https://hack.aragon.org/docs/aragonos-building.html](https://hack.aragon.org/docs/aragonos-building.html)
+    - [Reference and documentation for aragonOS 4](https://hack.aragon.org/docs/aragonos-ref.html) as well as a [list of the changes that have been made for aragonOS 4 from aragonOS 3](https://github.com/aragon/aragonOS/wiki/aragonOS-4:-Updates-to-aragonOS-and-aragon-apps).
+    - [Documentation on how aragonOS apps should be developed](https://hack.aragon.org/docs/aragonos-building.html).
+    - [Documentation for our smart contract deployments to live networks](https://github.com/aragon/deployments).
+
 
 ## Eligibility
 
 !!! success "Terms for eligible bounties"
-    - Only unknown vulnerabilities will be awarded with a bounty, in case of duplicate reports, the first report will be awarded the bounty.
-    - Public disclosure of the vulnerability before explicit consent from Aragon to do so, will make the vulnerability ineligible for a bounty.
+    - Only unknown vulnerabilities will be awarded with a bounty; in case of duplicate reports, the first report will be awarded the bounty.
+    - Public disclosure of the vulnerability, before explicit consent from Aragon to do so, will make the vulnerability ineligible for a bounty.
     - Attempting to exploit the vulnerability in a public Ethereum network will also make it ineligible for a bounty.

--- a/docs/dev/bug_bounty.md
+++ b/docs/dev/bug_bounty.md
@@ -20,9 +20,9 @@ Vulnerability reports will be scored using the  [CVSS v3](https://www.first.org/
 
 Rewards will be awarded at the sole discretion of the Aragon Association. Quality of the report and reproduction instructions can impact the reward. Rewards will be paid out in ETH.
 
-For this initial bug bounty program there is a **maximum bounty pool of $250,000**.
+For this initial bug bounty program, there is a **maximum bounty pool of $250,000**.
 
-The bug bounty program will run for a minimum of three months, starting October 17th 2018.
+The bug bounty program will run for a minimum of three months, starting October 17th, 2018.
 
 ## Reporting
 
@@ -37,7 +37,7 @@ The bug bounty program will run for a minimum of three months, starting October 
 In scope for the bug bounty are all the smart contract components of the Aragon client. They can be found on three main repositories:
 
 !!! abstract "**aragonOS 4** ([https://github.com/aragon/aragonOS@4.0.0](https://github.com/aragon/aragonOS/tree/v4.0.0) and [future patch versions](https://github.com/aragon/aragonOS/releases))"
-    Smart contract framework and core of the system.
+    Smart contract framework and the core of the system.
 
     - Solidity code under the `contracts` directory:
         - Excluding `contracts/lib/ens` contracts
@@ -69,7 +69,7 @@ You can find their deployed addresses on live networks in our [deployment docume
 
 !!! question "What we consider out of scope for this bug bounty"
     - Side-effects of properly authenticated smart contract upgrades or contract upgrades that change the storage layout of a contract.
-    - Revocation of permissions or completely changing how a DAO operates due to an important permission being granted through the proper processes.
+    - Revocation of permissions or completely changing how a DAO operates due to important permission being granted through the proper processes.
     - Any frontend applications or client-side code interacting with the contracts, as well as testing code.
     - Mismatch of the functionality of the contracts and outdated spec documents.
 
@@ -84,6 +84,6 @@ You can find their deployed addresses on live networks in our [deployment docume
 ## Eligibility
 
 !!! success "Terms for eligible bounties"
-    - Only unknown vulnerabilities will be awarded with a bounty; in case of duplicate reports, the first report will be awarded the bounty.
+    - Only unknown vulnerabilities will be awarded a bounty; in case of duplicate reports, the first report will be awarded the bounty.
     - Public disclosure of the vulnerability, before explicit consent from Aragon to do so, will make the vulnerability ineligible for a bounty.
     - Attempting to exploit the vulnerability in a public Ethereum network will also make it ineligible for a bounty.

--- a/docs/dev/bug_bounty.md
+++ b/docs/dev/bug_bounty.md
@@ -24,6 +24,14 @@ For this initial bug bounty program there is a **maximum bounty pool of $250,000
 
 The bug bounty program will run for a minimum of three months, starting October 17th 2018.
 
+## Reporting
+
+!!! note "Reporting a found vulnerability"
+    - In order to report a vulnerability, please write an email to security@aragon.org with [BUG BOUNTY] in the subject of the email.
+    - For sensitive vulnerabilities, please the encrypt the email using this [PGP key](rsc/security.asc) (Fingerprint: `B6D5 1396 4B9C 62B7`)
+    - We will make our best effort to reply in a timely manner and provide a timeline for resolution.
+    - Please include a detailed report on the vulnerability with clear reproduction steps. The quality of the report can impact the reward amount.
+
 ## Scope
 
 In scope for the bug bounty are all the smart contract components of the Aragon client. They can be found on three main repositories:
@@ -76,11 +84,3 @@ In scope for the bug bounty are all the smart contract components of the Aragon 
     - Only unknown vulnerabilities will be awarded with a bounty, in case of duplicate reports, the first report will be awarded the bounty.
     - Public disclosure of the vulnerability before explicit consent from Aragon to do so, will make the vulnerability ineligible for a bounty.
     - Attempting to exploit the vulnerability in a public Ethereum network will also make it ineligible for a bounty.
-
-## Reporting
-
-!!! note "Reporting a found vulnerability"
-    - In order to report a vulnerability, please write an email to security@aragon.org with [BUG BOUNTY] in the subject of the email.
-    - For sensitive vulnerabilities, please the encrypt the email using this [PGP key](rsc/security.asc) (Fingerprint: `B6D5 1396 4B9C 62B7`)
-    - We will make our best effort to reply in a timely manner and provide a timeline for resolution.
-    - Please include a detailed report on the vulnerability with clear reproduction steps. The quality of the report can impact the reward amount.

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -1,3 +1,13 @@
 # Aragon Development Overview
 
-The **[Developer Portal](https://hack.aragon.org)** provides all info you need to get started creating Aragon apps.
+The **[Developer Portal](https://hack.aragon.org)** provides all the info you need to get started creating Aragon apps.
+
+The Aragon Assocation develops the [Aragon client](https://github.com/aragon/aragon) as a reference implementation for managing and navigating aragonOS-powered organizations, as well as a [set of Aragon apps](https://github.com/aragon/aragon-apps) which act as the initial functionality provided in all Aragon 0.6 organizations. Both are internally powered by a [JavaScript implementation of aragonAPI](https://github.com/aragon/aragon.js).
+
+## Bug reports and feature requests
+
+If you have encountered a bug with the Aragon client or would like to request additional features, please provide feedback by filing an issue in the [Aragon client repo](http://github.com/aragon/aragon) or sending us a message on our [#feedback channel](https://aragon.chat/channel/feedback).
+
+## Security and smart contract bug reports
+
+Bug bounties are available for security vulnerabilities affecting any smart contracts supporting the Aragon client. Please visit the [bug bounty page](./bug_bounty) for more information and how you can responsibly report issues to us.

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -2,7 +2,7 @@
 
 The **[Developer Portal](https://hack.aragon.org)** provides all the info you need to get started creating Aragon apps.
 
-The Aragon Assocation develops the [Aragon client](https://github.com/aragon/aragon) as a reference implementation for managing and navigating aragonOS-powered organizations, as well as a [set of Aragon apps](https://github.com/aragon/aragon-apps) which act as the initial functionality provided in all Aragon 0.6 organizations. Both are internally powered by a [JavaScript implementation of aragonAPI](https://github.com/aragon/aragon.js).
+The Aragon Association develops the [Aragon client](https://github.com/aragon/aragon) as a reference implementation for managing and navigating aragonOS-powered organizations, as well as a [set of Aragon apps](https://github.com/aragon/aragon-apps) which act as the initial functionality provided in all Aragon 0.6 organizations. Both are internally powered by a [JavaScript implementation of aragonAPI](https://github.com/aragon/aragon.js).
 
 ## Bug reports and feature requests
 

--- a/docs/dev/security_disclosure.md
+++ b/docs/dev/security_disclosure.md
@@ -1,5 +1,0 @@
-# Security Vulnerability Disclosure Policy
-
-Until Aragon DAOs are deployed onto the mainnet, we kindly ask all security vulnerabilities to be publicly disclosed by filing issues under the relevant repos in our [GitHub organization](http://github.com/aragon/). Most likely, the vulnerability will fall under either [aragonOS](http://github.com/aragon/aragonOS), [aragon-apps](http://github.com/aragon/aragon-apps), [Aragon client](http://github.com/aragon/aragon), or [aragonAPI](http://github.com/aragon/aragon.js).
-
-We will revise our policy as we begin deploying contracts to the mainnet.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,6 @@ pages:
       - Vault: 'dev/apps/vault.md'
       - Finance: 'dev/apps/finance.md'
     - Bug bounty: 'dev/bug_bounty.md'
-    - Security disclosure: 'dev/security_disclosure.md'
   - Tutorials:
     - Aragon User Guide: 'tutorials/Aragon_User_Guide.md'
     - DAO Workshop For Aragon Core v0.5: 'tutorials/DAO_Workshop_Testnet_by_joselfgaray.md'


### PR DESCRIPTION
Removes the outdated security disclosure document, and provides links to the bug bounty in the development section's index.

Also rewords some text, uses "the Association" instead of just "Aragon", and orders the reporting section to be first (worried people will miss it if it's at the bottom).