### PR TITLE
Add Melon to Third Party Projects page, remove projects without proof

### DIFF
--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -27,7 +27,7 @@
 
 - [District0x](https://district0x.io) ([Proof](https://education.district0x.io/district0x-specific-topics/understanding-technology-behind-district0x/aragon/))
 
-- [Melon](https://melonport.com/) ([Proof](https://medium.com/melonport-blog/melon-will-run-its-decentralized-governance-on-aragon-9f7935693720))
+- [Melonport](https://melonport.com/) ([Proof](https://medium.com/melonport-blog/melon-will-run-its-decentralized-governance-on-aragon-9f7935693720))
 
 - [Spice VC](https://www.spicevc.com) ([Proof](https://medium.com/spicevc/spice-vc-is-the-first-to-use-blockchain-to-solve-the-liquidity-problem-638227217cb6))
 

--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -13,32 +13,24 @@
 > Uses [Proxy](https://hack.aragon.org/docs/aragonos-ref.html#3-upgradeability) feature from aragonOS as a part of their liquidPledging system and will eventually move the entire DApp to Aragon.
 
 ## Powered by Aragon
-> **Aragon Network went [live on the Mainnet](https://blog.aragon.org/aragon-06-is-live-on-mainnet/) on October 30th, 2018. This is still a bit fresh to DAOify your organization, this is a list of projects that have publicly announced their interest in utilizing Aragon, we can't wait to see what they do!**
+> **Aragon went [live on the Ethereum mainnet](https://blog.aragon.org/aragon-06-is-live-on-mainnet/) on October 30th, 2018. This is a list of projects that have publicly announced their interest in utilizing Aragon, we can't wait to see what they do!**
 >
 > See also our [guidelines](../design/powered_by_aragon.md) for projects "_Powered by Aragon_".
 >
-> This is a list of existing projects that have publicly announced their plan **to become** "_Powered by Aragon_":
+> This is a list of existing projects that have publicly announced their plan **to become** "_Powered by Aragon_". You can add your project to this list by submitting a pull request modifying [this page](https://github.com/aragon/aragon-wiki/edit/master/docs/projects/index.md) on the Aragon Wiki GitHub repo. Please include a link to your project's home page and a "Proof" link to some documentation that describes how your project is using Aragon.
 
-- [District0x](https://district0x.io)
+- [Althea](https://altheamesh.com/) ([Proof](https://blog.althea.org/althea-development-update--56--network-organization-support/))
 
-- [Aragon DAC](https://aragondac.org)
+- [Aragon DAC](https://aragondac.org) ([Proof](https://medium.com/aragon-dac/aragon-dac-a-new-community-effort-to-foster-aragons-development-led-by-giveth-2228dcc17b63))
 
-- [Request Network](https://request.network)
+- [Auctus](https://auctus.org/) ([Proof](https://blog.auctus.org/launch-of-auctus-labs-9ff5ffe26e32))
 
-- [Spice VC](https://www.spicevc.com)
+- [District0x](https://district0x.io) ([Proof](https://education.district0x.io/district0x-specific-topics/understanding-technology-behind-district0x/aragon/))
 
-- [Swarm Fund](http://swarm.fund)
+- [Melon](https://melonport.com/) ([Proof](https://medium.com/melonport-blog/melon-will-run-its-decentralized-governance-on-aragon-9f7935693720))
 
-- [Auctus](https://auctus.org/)
+- [Spice VC](https://www.spicevc.com) ([Proof](https://medium.com/spicevc/spice-vc-is-the-first-to-use-blockchain-to-solve-the-liquidity-problem-638227217cb6))
 
-- [Democracy Earth](https://democracy.earth)
+- [Request Network](https://request.network) ([Proof](https://blog.request.network/blockchain-bricks-request-is-built-upon-0x-civic-and-aragon-3aaf68390221))
 
-- [Shasta](https://shasta.world/)
-
-- [Althea](https://altheamesh.com/)
-
-![](../images/projects/althea.jpg)
-
-- [That Planning Tab](https://github.com/aragon/nest/pull/24)
-
-![](../images/projects/that_planning_tab.jpg)
+- [Shasta](https://shasta.world/) ([Proof](https://medium.com/shastaproject/how-we-plan-to-use-aragon-organizations-63d11fecc81d))


### PR DESCRIPTION
- Adds info about adding a project to this list
- Also removes images, which looked out of place
- Removed That Planning Suite since I don't think this is the right place to put a list of Aragon apps