### PR TITLE
Fix for "Aragon Core User Guide link leads to a broken looking page"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,4 @@
 site_name: 'Aragon Wiki'
-site_url: https://wiki.aragon.org
 repo_name: 'aragon/aragon-wiki'
 repo_url: 'https://github.com/aragon/aragon-wiki'
 site_description: 'Wiki for the Aragon Project'


### PR DESCRIPTION
This PR Resolves #376.

Refer to this: https://github.com/mkdocs/mkdocs/issues/1598

Tested locally on 'mkdocs serve'.