### PR TITLE
Fix broken link

### DIFF
--- a/docs/dev/apps/voting.md
+++ b/docs/dev/apps/voting.md
@@ -93,4 +93,4 @@ Any open votes will maintain the value minimum acceptance quorum was when they w
 
 #### Forwarding
 
-[Forwarding](../../documentation/aragonOS/#forwarders) using the common interface executes a `votingApp.newVote(...)` action. ACL is checked for whether the sender has permissions to create a vote.
+[Forwarding](https://hack.aragon.org/docs/forwarding-intro) using the common interface executes a `votingApp.newVote(...)` action. ACL is checked for whether the sender has permissions to create a vote.


### PR DESCRIPTION
https://wiki.aragon.org/dev/documentation/aragonOS/#forwarders returns a 404 error page. This PR fixes that.