### PR TITLE
Adding All devs and Strategy-WG notes

### DIFF
--- a/docs/all_aragon_devs/meeting_notes/alldevs20190916.md
+++ b/docs/all_aragon_devs/meeting_notes/alldevs20190916.md
@@ -1,0 +1,147 @@
+---
+tags: alldevs
+---
+
+# All Aragon Devs #31 (Notes)
+Call #31: september 16, 2019 8am PST / 11am EST / 3pm UTC / 5pm CEST
+
+- [Audio/video of the meeting](https://youtu.be/Dyv1afwZKXo)
+- [See notes](#notes)
+
+### Agenda
+* Appoint note takers
+* Introduce team members who haven’t already met each other (~0-5min)
+* Updates from the last call and current priorities
+    * Aragon One (~5min)
+    * Autark (~5min)
+    * Open Work Labs (~2min)
+    * Aragon Mesh (~5min)
+    * Aragon Black (~5min)
+    * Association (~2min)
+* Topics
+
+
+### Notes
+
+#### Introductions
+
+
+### Updates
+
+#### Aragon One
+- Client
+    * Released Client V0.8
+    * Add templates for Open Enterprise and Fundraising
+- Court
+    - Finishing testing phase, integration tests and simulations remain
+    - Trying to plan out the rest of the year: audit, deployment tasks etc
+    - Proposal for it's launch will be determined this week
+
+
+#### Autark
+- Frontend Updates almost complete with new design system
+- Chad created a stubbed frontend system using localstorage
+- Storage has a complete Proof-of-concept and is moving to contract-based pinning
+- Finishing up templates and mixedbytes will start auditing them later this week
+    - Base template: all Open Enterprise Apps (will be released on mainnet)
+    - OE template with modified token manager
+    - OE + Discussions
+- Focus is on mainnet release, more generally
+* Design system finish, working on allocation
+* Front-end solution using mocking
+* Automate continue deployment for test rinkeby deployment
+* Initial Proof of Concept of contract base pinning
+* Audit on templates
+    * Open entreprise template
+    * Other two that relay on contracts 
+
+Next two week:
+* Finish update on the app and then publish
+
+#### Open Work Labs
+- Storage Work
+    - First task: Letting the client pin to an org's storage location
+    - Working to create more proofs of concept/ feature demos
+- Operational Plan: Newly created orgs will have a limited amount of space to pin to Autarks or Aragon's IPFS node
+
+#### Aragon Mesh
+- Backlog grooming for bugs and github issues: prioritized and released a patch
+- Fixed issues with ganache and aragen
+- Released new version of aragonCLI that includes client V0.8 and new ganache version
+- product planning for new aragonCLI: new features!
+- Onboarding Matthew and Sacha
+
+Question from Brett: What is the timeline for the new version of the CLI? 
+A: Still prioritizing features and roadmap to decide on features to include and development method to take before we can determine a possible release
+
+#### Aragon Black
+- Backend
+    * Finish update contract after the audit
+    * Almost done with reviewing the presale contract
+    - Done updating contracts
+    - Almost done reviewing the presale contracts
+    - Done updating the new template
+- Frontend
+    - Using library for charts that lacks a maintainer, refactoring to create more meaningful charts, new features as trends
+    - Working to foster a better workflow
+    - Working with A1 on the onboarding screen for creating a new fundraising instance
+    - Will be working to get this out to mainnet as soon as possible, hopefully before Devcon V
+
+#### Aragon Association
+- We're Hiring: Operations Manager
+- Still in process of deploying Nest DAO
+    - Will be call on Thursday for Q&A on Nest DAO
+- Flock governance process under development
+    - Improve aplicationn process, currently a bit ambiguous as to what's needed to apply
+
+
+### Discussions 
+
+#### Opening up the aragon Github organization to community members (A1)
+* Know who are developers of the Aragon organization
+* Label users as Aragon dev community members
+* Transition the GitHub orgs to a more open community of contribution
+* Should start transitioning the Aragon org on Github to be more open and allow users to represent themselves as contributors to the Aragon github org
+* Having a type of badge that show people contribution on diferent topics
+* The biggest challenge is finding contributors outside github who have done valuable stuff in the forum and chat and elsewhere 
+
+
+#### [Major League Hacking](https://mlh.io/) / other hackathon participation (A1)
+* Query to see if we are getting involve in this
+* Wondering if we want to start showing up
+* Casual hackathoon that university from Europe and USA organize
+* Action item: define what we need from these hackathons and what are our goals do we want talent or testing? students attracted by 1: novelty and 2: opportunities (such as internship)
+* Maybe we could link that to the 'Aragon Academy'
+- Should we be doing more university outreach going forward? There aren't many left right now
+- The season goes from the Fall to the early Spring
+- [North America](https://mlh.io/seasons/na-2020/events)
+- [Europe](https://mlh.io/seasons/eu-2020/events)
+
+#### How should the GUI & CLI clients support apps without contracts (that may concern only the user, or may provide an UI alternative) ? (Mesh)
+* Having the ability to use CLI extensions
+* Have a way to install and uninstall them, how they comunicate with each other
+* the pando app could extend th cli
+- Might be good to build an extension pathway around building apps that don't need contracts
+* An idea is to use a microkernel architecture and be closelly related with the UI
+* How to deal with apps that don't have contracts?
+    * Decouple this between diferent APM repos?
+
+
+### Attendance
+
+Aragon Black: Xavier, Olivier
+
+Aragon Mesh: Daniel, Gabi
+
+Aragon One: Pierre, Bingen, Luke, Facu, Jorge, Brett
+
+Autark: Arthur, Kevin, Emilio, Otto, Chad
+
+Open Work Labs: John
+
+Aragon Association: Louis
+
+Community:
+
+### License
+This template is modified from the Ethereum All Core Devs call notes template and inherits the same CC-BY-SA 3.0 License.

--- a/docs/all_aragon_devs/meeting_notes/alldevs20190916.md
+++ b/docs/all_aragon_devs/meeting_notes/alldevs20190916.md
@@ -1,6 +1,3 @@
----
-tags: alldevs
----
 
 # All Aragon Devs #31 (Notes)
 Call #31: september 16, 2019 8am PST / 11am EST / 3pm UTC / 5pm CEST

--- a/docs/all_aragon_devs/meeting_notes/alldevs20190930.md
+++ b/docs/all_aragon_devs/meeting_notes/alldevs20190930.md
@@ -1,6 +1,3 @@
----
-tags: alldevs
----
 
 # All Aragon Devs #32 (Notes)
 Call #32: month day, 2019 8am PST / 11am EST / 3pm UTC / 5pm CEST

--- a/docs/all_aragon_devs/meeting_notes/alldevs20190930.md
+++ b/docs/all_aragon_devs/meeting_notes/alldevs20190930.md
@@ -1,0 +1,169 @@
+---
+tags: alldevs
+---
+
+# All Aragon Devs #32 (Notes)
+Call #32: month day, 2019 8am PST / 11am EST / 3pm UTC / 5pm CEST
+
+- [Audio/video of the meeting](https://youtu.be/12hGuuBMo9s)
+- [See notes](#notes)
+
+### Agenda
+* Appoint note takers (Chad & Jorge)
+* Introduce team members who haven’t already met each other (~0-5min)
+* Updates from the last call and current priorities
+    * Aragon One (~5min)
+    * Autark (~5min)
+    * Open Work Labs (~2min)
+    * Aragon Mesh (~5min)
+    * Aragon Black (~5min)
+    * Association (~2min)
+* Topics
+
+
+### Notes
+
+#### Introductions
+
+
+### Updates
+
+#### Aragon One
+
+- 0.8.2 release is planned right before Devcon
+- On the network:
+    - Deployment of Aragon court and ANJ which will use fundraising
+    - Published launch plan on forum
+    - Development of court is going well, talking to auditors now. Starting with individual audit on week of Nov. 21st
+    - Added last features, working on emergency mechanism for court. 
+    - Everything on schedule
+
+
+#### Autark
+
+Last two weeks
+- Address Book identity provider integration - Done but needs internal review
+- One follow up comment left from the audit we're resolving today based on the changes we submitted for review last week
+- developed the frontend for the open enterprise onboarding for the client and submitted PR. 
+- Doing some final touches on the template contracts this week
+- finished design system upgrade for Allocations and Rewards.
+- Made some small changes to the CLI for our needs, and moved towards using current version thanks to some changes from Mesh
+- First draft of documentation for all apps completed
+- Wrote step by step user test script for our bounty program we are kicking off this week
+- Polished up radspec for our OE contracts
+- Profiles (see owl)
+
+
+Next 2-3 weeks
+- Wrapping up our web3 integrations, template and launching open enterprise to Rinkeby 
+- Polish up docs and user test script 
+- Prepare app assets, screenshots, manifests
+- Test and fine tune apps in preparation for mainnet
+- Devcon & offsite in Osaka
+
+#### Open Work Labs
+
+- Storage solution updated
+- On server-side: building Ethereum event-based pinning
+- Will be having conversations to figure out how to implement this stuff more natively in Aragon
+- Profiles
+    - Figuring out how to implement it
+    - Keeping up with changes: web3 & aragonUI updates
+
+#### Aragon Mesh
+
+Last two weeks:
+
+- Dev support
+- Released new version of aragonCLI which allows passing array arguments to templates
+- Fixed intermittent issue with `@aragon/wrapper`; now support latest version of beta wrapper
+- New feature to link deployed libraries to contracts
+- Defined next version of CLI and what it should look like; will discuss further to get feedback
+
+Next two weeks:
+
+- Devcon
+- Finish work-in-progress to include permissions with parameter for the ACL 
+- Nest proposal. Main focus: having power user be at the center of new aragonCLI version. Proposal will include documentation for new users as well as this new power user topic.
+
+#### Aragon Black
+
+- Fundraising frontend almost done
+- Taking the week to test everything; should be ok
+- Last step is to wait for audit feedback; there's been a miscommunication issue there; had trouble booking the audit
+    - They're doing the audit now
+    - Only half of the audit, though
+    - Discussed with Brett; think the best strategy is to await this half-audit then deploy to Rinkeby
+    - Wait until full audit/report complete to fully release to mainnet
+- Rinkeby release to be done before Devcon
+- Final audit & mainnet release to follow
+
+#### Aragon Association
+
+- Hiring; finding right candidate for ops & hybrid role. Please send recommendations!
+- Starting process for launching Nest DAO. In-progress. Expect more communications about this.
+- Coordinating for security audit for releases (Aragon Black's & Autark's)
+- Updating the wiki to give increased transparency to current & future members of the ecosystem
+- Lots of interesting discussions in the forum ([one](https://forum.aragon.org/t/birds-of-a-feather/1277), [two](https://forum.aragon.org/t/an-optimists-take-on-flock/1299), [three](https://forum.aragon.org/t/aragons-cathedral-a-not-that-optimistic-take-on-flock/1300))
+
+Next two weeks:
+
+- Devcon
+
+
+### Discussions
+
+#### Template
+
+- Contracts going through audit
+- Frontend PR submitted
+
+#### Frontend Triggers
+
+This relates to [a change under review for the aragon.js repo](https://github.com/aragon/aragon.js/pull/361/files). Autark needs this change to restore functionality to their Projects & Rewards apps after the v0.8 client update. If needed, Autark can make changes with direction on the architecture from Brett: Route these trigger observables through a specific app context as opposed to inside the root of the wrapper
+
+#### Open Enterprise Release Requirements
+The plan is to get aragon.js changes for the FE triggers on rinkeby.aragon.org early/mid-week so we can start our community test/bounty program. Onboarding FE template done and PR submitted into aragon/aragon; need to integrate it with the contract which is going through testing. Targeting Friday Oct 4 or Monday/Tue Oct 7/8 for mainnet soft launch. Worst case scenario is crunching through Devcon and mainnet Oct 11.
+
+The *AddressBook IdentityProvider integration* is important for doing a bigger launch announcement, but we plan to soft launch next week to reduce the pressure on last minute PRs (as we were previously told there wouldn't be time to get this merged before Devcon). The integration is currently under [internal review within Autark](https://github.com/AutarkLabs/aragon.js/pull/31).
+
+#### Devcon dinner
+
+A bunch of people from Aragon community will be at Devcon. Let's have dinner together! Louis will help coordinate. If you're interested, please ping Louis or Jorge. This will be organized offline.
+
+#### Strategy for integrating aragon profile into the client
+
+What Jon thinks might be best: 
+
+- Profiles are at a pretty good place to merge in a soft- / not-public-launch sort of way. Almost like an Easter egg. 
+- It's currently integrated very lightly; clicking your user address in the new 0.8 client brings you to your profile. That's it. 
+- There are other gateways we could start to implement: 
+    - in the address pop-over, we could add a "go to profile" link. 
+    - We could add 3box as a full IdentityProvider so we can resolve names and avatars. 
+- There's also a question of design: Paty created some great-looking new designs; not sure the timeline for porting to these new designs, but we might not need to do that before initial soft-launch. 
+- We spent a long time getting Profiles to this point; it might make sense to merge it now and get some initial user feedback before continuing to polish this PR.
+
+Do we want to do this, or do we want to make sure we add particular functionality before reviewing & merging?
+
+#### Next version of aragonCLI 
+
+Do we want a users-version of the CLI and a dev-version of the CLI?
+
+### Attendance
+
+Aragon Black: Olivier
+
+Aragon Mesh: Gabi
+
+Aragon One: Brett, Jorge, Pierre
+
+Autark: Kevin, Arthur, Yalda, Chad, Peter, Radek, Emilio
+
+Open Work Labs: Jon
+
+Aragon Association: Louis
+
+Community:
+
+### License
+This template is modified from the Ethereum All Core Devs call notes template and inherits the same CC-BY-SA 3.0 License.

--- a/docs/all_aragon_devs/overview.md
+++ b/docs/all_aragon_devs/overview.md
@@ -7,4 +7,4 @@ To participate in the call, send an email to alldevs-at-aragon-dot-org with your
 
 # Next meeting agenda
 
-[All Devs #31](https://hackmd.io/@lg/S1QVc2qSr): September 16, 2019 8am PST / 11am EST / 3pm UTC / 5pm CEST
+[All Devs #33](https://hackmd.io/@lg/SJ-8hAx_B): October 14, 2019 8am PST / 11am EST / 3pm UTC / 5pm CEST

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,7 +127,7 @@ nav:
       - Media Mentions: 'media/press/media-mentions.md'
   - Help and tutorials:
     - Aragon Knowledge Base: 'https://help.aragon.org/'
-  - Aragon jobs: 
+  - Aragon jobs:
     - See who's hiring: 'jobs/index.md'
   - All Aragon Devs:
     - Overview: 'all_aragon_devs_/overview.md'
@@ -136,6 +136,8 @@ nav:
     - Meeting Notes:
       - September 2019:
         - 02.09.2019: 'all_aragon_devs/meeting_notes/alldevs20190902.md'
+        - 16.09.2019: 'all_aragon_devs/meeting_notes/alldevs20190916.md'
+        - 30.09.2019: 'all_aragon_devs/meeting_notes/alldevs20190930.md'
       - August 2019:
         - 19.08.2019: 'all_aragon_devs/meeting_notes/alldevs20190819.md'
         - 05.08.2019: 'all_aragon_devs/meeting_notes/alldevs20190805.md'
@@ -189,6 +191,8 @@ nav:
         - 02.08.2019: 'working-groups/meeting-notes/strategy-wg/Strategycall20190802.md'
         - 16.08.2019: 'working-groups/meeting-notes/strategy-wg/Strategycall20190816.md'
         - 30.08.2019: 'working-groups/meeting-notes/strategy-wg/Strategycall20190830.md'
+        - 13.09.2019: 'working-groups/meeting-notes/strategy-wg/Strategycall20190913.md'
+        - 27.09.2019: 'working-groups/meeting-notes/strategy-wg/Strategycall20190927.md'
   - Community and social media:
     - Aragon Chat: 'https://aragon.chat'
     - Aragon Forum: 'https://forum.aragon.org'


### PR DESCRIPTION
- modifying mkdocs file so strategy WG notes appear on the wiki
- adding notes for the last two all devs
- updating the all devs agenda link and date in the overview.md