### PR TITLE
Security: Add Aragon Network bug bounty program (Part 2)

### DIFF
--- a/docs/association/security/an_bug_bounty.md
+++ b/docs/association/security/an_bug_bounty.md
@@ -35,7 +35,7 @@ The bug bounty program is ongoing and has been running since November 25th, 2019
 
 In scope for the bug bounty are all the smart contract components of the Aragon Network. They can be found in the following repositories:
 
-!!! abstract "**Aragon Court** ([v1](https://github.com/aragon/aragon-court/tree/v1.0.0) and [future minor versions](https://github.com/aragon/aragon-court/releases))"
+!!! abstract "**Aragon Court protocol** ([v1](https://github.com/aragon/aragon-court/tree/v1.0.0) and [future minor versions](https://github.com/aragon/aragon-court/releases))"
     Dispute resolution protocol.
 
     - Solidity code under the `contracts` directory:
@@ -43,12 +43,12 @@ In scope for the bug bounty are all the smart contract components of the Aragon 
         - Excluding `contracts/test/`
         - Excluding `contracts/standards/`
 
-!!! abstract "**Aragon Network fundraising** ([v1](https://github.com/aragonone/fundraising/tree/v1.0.0) and [future minor versions](https://github.com/aragonone/fundraising/releases))"
+!!! abstract "**Aragon Court fundraising** ([v1](https://github.com/aragonone/court-presale/tree/v1.0.0) and [future minor versions](https://github.com/aragonone/court-presale/releases))"
     Smart contracts for the Aragon Network fundraising process
 
     - Only the following Solidity contracts:
-        - `apps/presale/contracts/BalanceRedirectPresale.sol`
-        - `templates/multisig/contracts/CourtFundraisingMembershipTemplate.sol`
+        - `app/contracts/BalanceRedirectPresale.sol`
+        - `template/contracts/EOPBCTemplate.sol`
         
 !!! abstract "**Aragon Network deployment** ([v1](https://github.com/aragon/aragon-network-deploy/tree/rc-1.0.0) and [future minor versions](https://github.com/aragon/aragon-network-deploy/releases))"
     Deployment commands for the Aragon Network components

--- a/docs/association/security/an_bug_bounty.md
+++ b/docs/association/security/an_bug_bounty.md
@@ -43,8 +43,8 @@ In scope for the bug bounty are all the smart contract components of the Aragon 
         - Excluding `contracts/test/`
         - Excluding `contracts/standards/`
 
-!!! abstract "**Aragon Court fundraising** ([v1](https://github.com/aragonone/court-presale/tree/v1.0.0) and [future minor versions](https://github.com/aragonone/court-presale/releases))"
-    Smart contracts for the Aragon Network fundraising process
+!!! abstract "**Aragon Court pre-activation** ([v1](https://github.com/aragonone/court-presale/tree/v1.0.0) and [future minor versions](https://github.com/aragonone/court-presale/releases))"
+    Smart contracts for the Aragon Network pre-activation process
 
     - Only the following Solidity contracts:
         - `app/contracts/BalanceRedirectPresale.sol`

--- a/docs/association/security/an_bug_bounty.md
+++ b/docs/association/security/an_bug_bounty.md
@@ -43,6 +43,13 @@ In scope for the bug bounty are all the smart contract components of the Aragon 
         - Excluding `contracts/test/`
         - Excluding `contracts/standards/`
 
+!!! abstract "**Aragon Network fundraising** ([v1](https://github.com/aragonone/fundraising/tree/v1.0.0) and [future minor versions](https://github.com/aragonone/fundraising/releases))"
+    Smart contracts for the Aragon Network fundraising process
+
+    - Only the following Solidity contracts:
+        - `apps/presale/contracts/BalanceRedirectPresale.sol`
+        - `templates/multisig/contracts/CourtFundraisingMembershipTemplate.sol`
+        
 !!! abstract "**Aragon Network deployment** ([v1](https://github.com/aragon/aragon-network-deploy/tree/rc-1.0.0) and [future minor versions](https://github.com/aragon/aragon-network-deploy/releases))"
     Deployment commands for the Aragon Network components
 


### PR DESCRIPTION
**MERGE AFTER #530**

I split the bug bounty program into two parts since the fundraising contracts for the Aragon Court will be ready after the announcement date. We can update it afterward.